### PR TITLE
refactor(settings): L'évènement `settingsStart` n'utilisait pas `pageEventList`

### DIFF
--- a/main.js
+++ b/main.js
@@ -442,7 +442,10 @@ class AppMain extends BaseAppObject {
             `);
 
     win.webContents.on('dom-ready', () => {
-      win.webContents.postMessage('settingsStart', this.settings.filePath);
+      win.webContents.postMessage(
+        pageEventList.settingsStart,
+        this.settings.filePath,
+      );
     });
 
     win.show();

--- a/src/page.settings/settings.js
+++ b/src/page.settings/settings.js
@@ -1,4 +1,5 @@
 import { appEventList } from '../scripts/events/AppEventListModule.js';
+import { pageEventList } from '../scripts/events/PageEventListModule.js';
 
 export class PageSettings {
   constructor() {
@@ -7,7 +8,7 @@ export class PageSettings {
   }
 
   async main() {
-    window.api.on('settingsStart', async (_, path) => {
+    window.api.on(pageEventList.settingsStart, async (_, path) => {
       console.log('path', path);
       await fetch(path)
         .then(function (response) {

--- a/src/scripts/events/PageEventList.js
+++ b/src/scripts/events/PageEventList.js
@@ -12,5 +12,6 @@ const pageEventList = Object.freeze({
   init: 'init',
   appInserted: 'appInserted',
   windowAppsClosed: 'windowAppsClosed',
+  settingsStart: 'settingsStart',
 });
  module.exports = { pageEventList };

--- a/src/scripts/events/PageEventListBase.js
+++ b/src/scripts/events/PageEventListBase.js
@@ -12,4 +12,5 @@ const pageEventList = Object.freeze({
   init: 'init',
   appInserted: 'appInserted',
   windowAppsClosed: 'windowAppsClosed',
+  settingsStart: 'settingsStart',
 });

--- a/src/scripts/events/PageEventListModule.js
+++ b/src/scripts/events/PageEventListModule.js
@@ -12,4 +12,5 @@ export const pageEventList = Object.freeze({
   init: 'init',
   appInserted: 'appInserted',
   windowAppsClosed: 'windowAppsClosed',
+  settingsStart: 'settingsStart',
 });


### PR DESCRIPTION
Suite à l'issue #7 la version [2.0.0](https://github.com/Rotomeca/rotomeca-toolbar/releases/tag/2.0.0) n'utilisait pas `PageEventList`.